### PR TITLE
feat: update Toaster component to support mobile positioning

### DIFF
--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -8,15 +8,32 @@ import {
   TriangleAlertIcon,
 } from "lucide-react"
 import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.matchMedia("(max-width: 768px)").matches)
+    }
+
+    checkMobile()
+    const mediaQuery = window.matchMedia("(max-width: 768px)")
+    mediaQuery.addEventListener("change", checkMobile)
+
+    return () => mediaQuery.removeEventListener("change", checkMobile)
+  }, [])
+
+  const position = isMobile ? "top-right" : "bottom-right"
 
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      position={position}
       richColors={true}
       icons={{
         success: <CircleCheckIcon className="size-4" />,


### PR DESCRIPTION
# PR: Implement Responsive Toast Positioning

## 📝 Description

This PR implements responsive positioning for toast notifications. It ensures that toasts appear at the top of the screen on mobile devices to prevent interference with the bottom navigation bar, while maintaining the standard bottom-right position on desktop screens.

## 🔗 Related Issue

Closes #89

## 🏷️ Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## 🔄 Changes Made

- Modified `components/ui/sonner.tsx` to include an `isMobile` state.
- Added a matchMedia listener to detect screen width changes (breakpoint at 768px).
- Set dynamic `position` for Sonner Toaster: `top-right` for mobile and `bottom-right` for desktop.
- Cleaned up manual prop drilling for position to use the internal responsive logic.

## 🧪 Testing

- [x] Manual testing completed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated

Tested by:
1. Triggering toasts in desktop view (verified bottom-right).
2. Resizing the browser to mobile width and triggering toasts (verified top-right).
3. Confirming that mobile navigation is no longer obstructed by successful/error notifications.

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 📸 Screens

https://github.com/user-attachments/assets/bfd1e438-d164-4414-a640-9ab35095e332

## 📌 Additional Notes

The breakpoint is set to 768px (standard md breakpoint) to ensure a consistent experience across most mobile and tablet devices.
