### PR TITLE
Feat persist user language preference

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -25,7 +25,7 @@ export default function SettingsPage() {
   const { t } = useTranslation()
   const router = useRouter()
   const { user, signOut, signOutPending } = useAuth()
-  const { settings, updateTheme, isUpdating: isUpdatingTheme } = useUserSettings()
+  const { settings, updateTheme, isUpdating: isUpdatingTheme, updateLanguage, isUpdatingLanguage } = useUserSettings()
   const { isInstallable, isInstalled, install: installPWA } = usePWAInstall()
 
   // Modal states
@@ -50,8 +50,16 @@ export default function SettingsPage() {
     }
   }
 
-  const handleLanguageChange = (lang: string) => {
+  const handleLanguageChange = async (lang: string) => {
+    // Optimistically update UI immediately
     i18n.changeLanguage(lang)
+
+    // Persist to database
+    try {
+      await updateLanguage(lang)
+    } catch (error) {
+      console.error("Error updating language:", error)
+    }
   }
 
   const currentTheme = settings?.theme || "system"
@@ -232,7 +240,7 @@ export default function SettingsPage() {
                   </div>
                   <Popover>
                     <PopoverTrigger asChild>
-                      <Button variant="outline" className="gap-2">
+                      <Button variant="outline" className="gap-2" disabled={isUpdatingLanguage}>
                         <span className="text-lg">{currentLanguage.flag}</span>
                         {t("settings.account.change")}
                       </Button>
@@ -242,7 +250,7 @@ export default function SettingsPage() {
                         {languages.map((lang) => (
                           <button
                             key={lang.code}
-                            disabled={lang.disabled}
+                            disabled={lang.disabled || isUpdatingLanguage}
                             onClick={() => handleLanguageChange(lang.code)}
                             className={cn(
                               "flex items-center gap-3 w-full px-3 py-2 text-sm font-medium rounded-md transition-colors group",

--- a/components/providers/LanguageSync.tsx
+++ b/components/providers/LanguageSync.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useUserSettings } from '@/hooks/useUserSettings';
+import i18n from '@/i18n';
+
+/**
+ * LanguageSync component
+ * 
+ * This component synchronizes the language from the database with i18next.
+ * It runs once when settings are loaded to ensure the language from DB is applied.
+ * 
+ * This is a separate component to ensure it runs at the app level and syncs
+ * language immediately when the user logs in.
+ */
+export function LanguageSync() {
+    const { settings } = useUserSettings();
+
+    useEffect(() => {
+        // Only sync when settings are loaded and user is authenticated
+        if (!settings?.language) {
+            return;
+        }
+
+        // Get current language (normalize to base code)
+        const currentLang = (i18n.language || 'en').split('-')[0];
+
+        // If the language from DB is different from current language, sync it
+        // This handles initial load when user logs in
+        if (settings.language !== currentLang) {
+            console.log(`[LanguageSync] Syncing language from DB: ${settings.language}`);
+            i18n.changeLanguage(settings.language);
+        }
+    }, [settings?.language]); // Only depend on settings.language to run once when loaded
+
+    // This component doesn't render anything
+    return null;
+}

--- a/components/providers/Providers.tsx
+++ b/components/providers/Providers.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import { Toaster } from '@/components/ui/sonner';
 import { ServiceWorkerProvider } from './ServiceWorkerProvider';
 import { ThemeSync } from './ThemeSync';
+import { LanguageSync } from './LanguageSync';
 import { TopLoadingBar } from './TopLoadingBar';
 import { NetworkStatusProvider } from './NetworkStatusProvider';
 
@@ -64,6 +65,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         disableTransitionOnChange
       >
         <ThemeSync />
+        <LanguageSync />
         <TopLoadingBar />
         <ServiceWorkerProvider>
           <NetworkStatusProvider>

--- a/hooks/useUserSettings.ts
+++ b/hooks/useUserSettings.ts
@@ -14,6 +14,7 @@ export type UserSettings = {
   id: string;
   user_id: string;
   theme: 'light' | 'dark' | 'system';
+  language: string;
   created_at: string;
   updated_at: string;
 };
@@ -85,6 +86,7 @@ export function useUserSettings() {
           .insert({
             user_id: user.id,
             theme: 'system',
+            language: 'en',
           })
           .select()
           .single();
@@ -141,6 +143,35 @@ export function useUserSettings() {
     },
   });
 
+  // Mutation to update language
+  const updateLanguageMutation = useMutation({
+    mutationFn: async (language: string) => {
+      if (!user?.id) {
+        throw new Error('User must be authenticated');
+      }
+
+      const supabase = createBrowserClient();
+
+      // Update language in database
+      const { data, error: updateError } = await supabase
+        .from('user_settings')
+        .update({ language })
+        .eq('user_id', user.id)
+        .select()
+        .single();
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      return data as UserSettings;
+    },
+    onSuccess: (data) => {
+      // Update cache with new settings
+      queryClient.setQueryData(userSettingsKeys.user(user?.id ?? null), data);
+    },
+  });
+
   // Sync theme from database to next-themes when settings load
   // This effect ensures next-themes is synchronized with the database theme
   useEffect(() => {
@@ -156,6 +187,32 @@ export function useUserSettings() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings?.theme, currentTheme]); // Include currentTheme to detect when it changes
+
+  // Sync language from database to i18next when settings load
+  // This effect ensures i18next is synchronized with the database language
+  // Runs on login and whenever settings change
+  useEffect(() => {
+    if (!settings?.language || !user?.id) {
+      // Don't sync if settings aren't loaded or user isn't authenticated
+      return;
+    }
+
+    // Import i18n dynamically to avoid circular dependencies
+    import('@/i18n').then((i18nModule) => {
+      const i18n = i18nModule.default;
+
+      // Always sync language from database when settings load
+      // This ensures language is restored on login
+      const currentLang = (i18n.language || 'en').split('-')[0];
+
+      if (settings.language !== currentLang) {
+        console.log(`[useUserSettings] Syncing language from DB: ${settings.language}`);
+        i18n.changeLanguage(settings.language);
+      }
+    }).catch((error) => {
+      console.error('[useUserSettings] Failed to sync language:', error);
+    });
+  }, [settings?.language, user?.id]);
 
   // Invalidate settings query when auth state changes
   useEffect(() => {
@@ -175,6 +232,9 @@ export function useUserSettings() {
     updateTheme: updateThemeMutation.mutateAsync,
     isUpdating: updateThemeMutation.isPending,
     updateError: updateThemeMutation.error as PostgrestError | null,
+    updateLanguage: updateLanguageMutation.mutateAsync,
+    isUpdatingLanguage: updateLanguageMutation.isPending,
+    updateLanguageError: updateLanguageMutation.error as PostgrestError | null,
   };
 }
 

--- a/supabase/migrations/20260131120000_add_language_to_user_settings.sql
+++ b/supabase/migrations/20260131120000_add_language_to_user_settings.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- Migration: Add language column to user_settings table
+-- ============================================================================
+-- Adds language preference column to store user's selected language
+-- Includes check constraint for valid language codes
+-- ============================================================================
+
+-- Add language column with default value
+ALTER TABLE public.user_settings 
+ADD COLUMN language TEXT NOT NULL DEFAULT 'en';
+
+-- Add check constraint to validate language codes
+ALTER TABLE public.user_settings
+ADD CONSTRAINT user_settings_language_check 
+CHECK (language IN ('en', 'es', 'pt', 'fr', 'de'));
+
+-- Backfill existing records with default language (already done by DEFAULT, but explicit for clarity)
+UPDATE public.user_settings 
+SET language = 'en' 
+WHERE language IS NULL;

--- a/types/database.ts
+++ b/types/database.ts
@@ -80,6 +80,7 @@ export type Database = {
         Row: {
           created_at: string
           id: string
+          language: string
           theme: string
           updated_at: string
           user_id: string
@@ -87,6 +88,7 @@ export type Database = {
         Insert: {
           created_at?: string
           id?: string
+          language?: string
           theme?: string
           updated_at?: string
           user_id: string
@@ -94,6 +96,7 @@ export type Database = {
         Update: {
           created_at?: string
           id?: string
+          language?: string
           theme?: string
           updated_at?: string
           user_id?: string
@@ -122,116 +125,116 @@ type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-  | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-  | { schema: keyof DatabaseWithoutInternals },
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-  ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-    DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-  : never = never,
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-    DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
-  ? R
-  : never
+    ? R
+    : never
   : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-    DefaultSchema["Views"])
-  ? (DefaultSchema["Tables"] &
-    DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-      Row: infer R
-    }
-  ? R
-  : never
-  : never
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-  | keyof DefaultSchema["Tables"]
-  | { schema: keyof DatabaseWithoutInternals },
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-  ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-  : never = never,
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-    Insert: infer I
-  }
-  ? I
-  : never
+      Insert: infer I
+    }
+    ? I
+    : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-  ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-    Insert: infer I
-  }
-  ? I
-  : never
-  : never
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-  | keyof DefaultSchema["Tables"]
-  | { schema: keyof DatabaseWithoutInternals },
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-  ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-  : never = never,
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-    Update: infer U
-  }
-  ? U
-  : never
+      Update: infer U
+    }
+    ? U
+    : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-  ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-    Update: infer U
-  }
-  ? U
-  : never
-  : never
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-  | keyof DefaultSchema["Enums"]
-  | { schema: keyof DatabaseWithoutInternals },
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-  ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-  : never = never,
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-  ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-  : never
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-  | keyof DefaultSchema["CompositeTypes"]
-  | { schema: keyof DatabaseWithoutInternals },
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-  ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-  : never = never,
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-  ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-  : never
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
   public: {


### PR DESCRIPTION
## 📝 Description

This PR implements persistent language preference storage in the database, allowing users' language selections to be saved and automatically restored across sessions and devices. Previously, language selection was only temporary and stored in localStorage, which meant users had to re-select their preferred language after logging in from different devices.

## 🔗 Related Issue

Closes #[issue-number] - Persist User Language Preference

## 🏷️ Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## 🔄 Changes Made

### Database Layer
- **Migration**: Added `language` column to `user_settings` table
  - Default value: `'en'`
  - Check constraint for valid language codes: `en`, `es`, `pt`, `fr`, `de`
  - Backfilled existing records with default language

### Backend/Hook Layer
- **`useUserSettings.ts`**: Enhanced user settings hook
  - Updated `UserSettings` type to include `language` field
  - Added `language` to default settings creation
  - Created `updateLanguage` mutation for database persistence
  - Added language sync effect with user authentication check
  - Exported `updateLanguage`, `isUpdatingLanguage`, and `updateLanguageError` for UI integration

### Frontend Layer
- **`LanguageSync.tsx`**: New component for automatic language restoration
  - Syncs language from database to i18next on app load
  - Runs at app level to ensure language is restored immediately on login
  - Includes console logging for debugging

- **`Providers.tsx`**: Integrated `LanguageSync` component
  - Added to provider tree alongside `ThemeSync`
  - Ensures language sync happens at the root level

- **`page.tsx` (Settings)**: Updated language selection UI
  - Modified `handleLanguageChange` to persist language to database
  - Added optimistic UI update for immediate feedback
  - Added loading states to language selector buttons
  - Disabled buttons during language update operation

## 🧪 Testing

- [x] Manual testing completed
  - ✅ Language selection persists after page refresh
  - ✅ Language selection persists across different sessions
  - ✅ Language is automatically restored on login
  - ✅ Database correctly stores selected language code
  - ✅ UI provides loading feedback during language update
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated

### Manual Testing Steps
1. Navigate to Settings page
2. Change language to Español
3. Verify UI updates immediately
4. Refresh the page → Language persists
5. Log out and log back in → Language is restored to Español
6. Check Supabase database → `user_settings.language` shows `'es'`

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 📸 Screenshots (if applicable)

_Screenshots showing language selection UI and persistence behavior would be helpful here._

## 📌 Additional Notes

### Database Migration
After merging this PR, the database migration must be applied:
```bash
npx supabase db push
```

Then regenerate TypeScript types:
```bash
npm run generate:types
```

### Language Detection Priority
The app now has the following language detection priority:
1. **Database** (highest) - Saved language for authenticated users
2. **localStorage** - Temporary language for non-authenticated users
3. **Browser/System** (fallback) - Automatic detection via `i18next-browser-languagedetector`

### Future Improvements
- Add unit tests for `LanguageSync` component
- Add integration tests for language persistence flow
- Consider adding language preference to user onboarding flow
